### PR TITLE
Simplify CMake and native features usage

### DIFF
--- a/recipes/loguru/all/CMakeLists.txt
+++ b/recipes/loguru/all/CMakeLists.txt
@@ -3,8 +3,6 @@ project(loguru LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
-
 option(LOGURU_USE_FMTLIB "Use fmtlib project to format text")
 
 option(LOGURU_SCOPE_TEXT_SIZE "Maximum length of text that can be printed by a LOG_SCOPE.")

--- a/recipes/loguru/all/CMakeLists.txt
+++ b/recipes/loguru/all/CMakeLists.txt
@@ -1,63 +1,56 @@
-cmake_minimum_required(VERSION 3.25)
-project(loguru)
+cmake_minimum_required(VERSION 3.8)
+project(loguru LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
-set(src loguru.cpp loguru.hpp)
+include(GNUInstallDirs)
 
-if (LOGURU_STATIC)
-    message("-- loguru: building a static library")
-    add_library(loguru STATIC ${src})
-else ()
-    message("-- loguru: building a shared library")
-    add_library(loguru SHARED ${src})
-endif ()
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+option(LOGURU_USE_FMTLIB "Use fmtlib project to format text")
+
+option(LOGURU_SCOPE_TEXT_SIZE "Maximum length of text that can be printed by a LOG_SCOPE.")
+option(LOGURU_FILENAME_WIDTH "Width of the column containing the file name")
+option(LOGURU_THREADNAME_WIDTH "Width of the column containing the thread name")
+option(LOGURU_SCOPE_TIME_PRECISION "Resolution of scope timers: 3=ms, 6=us, 9=ns")
+
+option(LOGURU_CATCH_SIGABRT "Should Loguru catch SIGABRT to print stack trace etc?")
+option(LOGURU_VERBOSE_SCOPE_ENDINGS "Show milliseconds and scope name at end of scope")
+option(LOGURU_REDEFINE_ASSERT "Redefine default c++ assert value")
+option(LOGURU_WITH_STREAMS "Extends loguru to enable std::stream-style logging")
+option(LOGURU_WITH_FILEABS "Check of file change will be performed on every call to file_log")
+option(LOGURU_RTTI "Support to runtime type information")
+option(LOGURU_REPLACE_GLOG "Make Loguru mimic GLOG as close as possible")
+
 
 if (LOGURU_USE_FMTLIB)
-    message("-- loguru: using fmtlib")
-    target_compile_definitions(loguru PUBLIC -DLOGURU_USE_FMTLIB)
     find_package(fmt CONFIG REQUIRED)
-    target_link_libraries(loguru PUBLIC fmt::fmt)
-endif ()
+endif()
 
-if (LOGURU_SCOPE_TEXT_SIZE)
-    message("-- loguru: setting LOGURU_SCOPE_TEXT_SIZE=${LOGURU_SCOPE_TEXT_SIZE}")
-    target_compile_definitions(loguru PUBLIC -DLOGURU_SCOPE_TEXT_SIZE=${LOGURU_SCOPE_TEXT_SIZE})
-endif ()
 
-if (LOGURU_FILENAME_WIDTH)
-    message("-- loguru: setting LOGURU_FILENAME_WIDTH=${LOGURU_FILENAME_WIDTH}")
-    target_compile_definitions(loguru PUBLIC -DLOGURU_FILENAME_WIDTH=${LOGURU_FILENAME_WIDTH})
-endif ()
+add_library(${PROJECT_NAME} ${LOGURU_SRC_DIR}/loguru.cpp ${LOGURU_SRC_DIR}/loguru.hpp)
+target_link_libraries(${PROJECT_NAME} PUBLIC $<$<BOOL:${LOGURU_USE_FMTLIB}>:fmt::fmt>)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+    PUBLIC_HEADER "${LOGURU_SRC_DIR}/loguru.hpp"
+)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    LOGURU_SCOPE_TEXT_SIZE=${LOGURU_SCOPE_TEXT_SIZE}
+    LOGURU_FILENAME_WIDTH=${LOGURU_FILENAME_WIDTH}
+    LOGURU_THREADNAME_WIDTH=${LOGURU_THREADNAME_WIDTH}
+    LOGURU_SCOPE_TIME_PRECISION=${LOGURU_SCOPE_TIME_PRECISION}
+    LOGURU_CATCH_SIGABRT=${LOGURU_CATCH_SIGABRT}
+    LOGURU_VERBOSE_SCOPE_ENDINGS=${LOGURU_VERBOSE_SCOPE_ENDINGS}
+    LOGURU_REDEFINE_ASSERT=${LOGURU_REDEFINE_ASSERT}
+    LOGURU_WITH_STREAMS=${LOGURU_WITH_STREAMS}
+    LOGURU_WITH_FILEABS=${LOGURU_WITH_FILEABS}
+    LOGURU_RTTI=${LOGURU_RTTI}
+    LOGURU_REPLACE_GLOG=${LOGURU_REPLACE_GLOG}
+)
 
-if (LOGURU_THREADNAME_WIDTH)
-    message("-- loguru: setting LOGURU_THREADNAME_WIDTH=${LOGURU_THREADNAME_WIDTH}")
-    target_compile_definitions(loguru PUBLIC -DLOGURU_THREADNAME_WIDTH=${LOGURU_THREADNAME_WIDTH})
-endif ()
-
-if (LOGURU_SCOPE_TIME_PRECISION)
-    message("-- loguru: setting LOGURU_SCOPE_TIME_PRECISION=${LOGURU_SCOPE_TIME_PRECISION}")
-    target_compile_definitions(loguru PUBLIC -DLOGURU_SCOPE_TIME_PRECISION=${LOGURU_SCOPE_TIME_PRECISION})
-endif ()
-
-message("-- loguru: setting LOGURU_CATCH_SIGABRT=${LOGURU_CATCH_SIGABRT}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_CATCH_SIGABRT=${LOGURU_CATCH_SIGABRT})
-
-message("-- loguru: setting LOGURU_VERBOSE_SCOPE_ENDINGS=${LOGURU_VERBOSE_SCOPE_ENDINGS}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_VERBOSE_SCOPE_ENDINGS=${LOGURU_VERBOSE_SCOPE_ENDINGS})
-
-message("-- loguru: setting LOGURU_REDEFINE_ASSERT=${LOGURU_REDEFINE_ASSERT}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_REDEFINE_ASSERT=${LOGURU_REDEFINE_ASSERT})
-
-message("-- loguru: setting LOGURU_WITH_STREAMS=${LOGURU_WITH_STREAMS}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_WITH_STREAMS=${LOGURU_WITH_STREAMS})
-
-message("-- loguru: setting LOGURU_WITH_FILEABS=${LOGURU_WITH_FILEABS}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_WITH_FILEABS=${LOGURU_WITH_FILEABS})
-
-message("-- loguru: setting LOGURU_WITH_RTTI=${LOGURU_WITH_RTTI}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_WITH_RTTI=${LOGURU_WITH_RTTI})
-
-message("-- loguru: setting LOGURU_REPLACE_GLOG=${LOGURU_REPLACE_GLOG}")
-target_compile_definitions(loguru PUBLIC -DLOGURU_REPLACE_GLOG=${LOGURU_REPLACE_GLOG})
-
-install(TARGETS loguru)
+install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/recipes/loguru/all/conanfile.py
+++ b/recipes/loguru/all/conanfile.py
@@ -122,18 +122,13 @@ class LoguruConan(ConanFile):
         self.cpp_info.defines.append(f"LOGURU_FILENAME_WIDTH={self.options.filename_width}")
         self.cpp_info.defines.append(f"LOGURU_THREADNAME_WIDTH={self.options.threadname_width}")
         self.cpp_info.defines.append(f"LOGURU_SCOPE_TIME_PRECISION={self.options.scope_time_precision}")
-        definitions = {
-            "LOGURU_CATCH_SIGABRT": self.options.catch_sigabrt,
-            "LOGURU_VERBOSE_SCOPE_ENDINGS": self.options.verbose_scope_endings,
-            "LOGURU_REDEFINE_ASSERT": self.options.redefine_assert,
-            "LOGURU_WITH_STREAMS": self.options.with_streams,
-            "LOGURU_WITH_FILEABS": self.options.with_fileabs,
-            "LOGURU_RTTI": self.options.with_rtti,
-            "LOGURU_REPLACE_GLOG": self.options.replace_glog
-        }
-        for key, value in definitions.items():
-            self.output.info(f"VALUE: {key} {value}")
-            self.cpp_info.defines.append(f"{key}={int(eval(value.value))}")
+        self.cpp_info.defines.append(f"LOGURU_CATCH_SIGABRT={int(eval(self.options.catch_sigabrt.value))}")
+        self.cpp_info.defines.append(f"LOGURU_VERBOSE_SCOPE_ENDINGS={int(eval(self.options.verbose_scope_endings.value))}")
+        self.cpp_info.defines.append(f"LOGURU_REDEFINE_ASSERT={int(eval(self.options.redefine_assert.value))}")
+        self.cpp_info.defines.append(f"LOGURU_WITH_STREAMS={int(eval(self.options.with_streams.value))}")
+        self.cpp_info.defines.append(f"LOGURU_WITH_FILEABS={int(eval(self.options.with_fileabs.value))}")
+        self.cpp_info.defines.append(f"LOGURU_RTTI={int(eval(self.options.with_rtti.value))}")
+        self.cpp_info.defines.append(f"LOGURU_REPLACE_GLOG={int(eval(self.options.replace_glog.value))}")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread", "dl"]

--- a/recipes/loguru/all/conanfile.py
+++ b/recipes/loguru/all/conanfile.py
@@ -1,18 +1,12 @@
 import os
 
-from conan import tools, ConanFile
+from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy, get, load, save
 from conan.tools.build import check_min_cppstd
 
+
 required_conan_version = ">=1.53.0"
-
-
-def _int(flag):
-    if flag is not None and flag:
-        return "1"
-    else:
-        return "0"
 
 
 class LoguruConan(ConanFile):
@@ -21,12 +15,13 @@ class LoguruConan(ConanFile):
     exports_sources = 'CMakeLists.txt'
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/emilk/loguru"
-    license = "Unlicense"  # Public domain
+    license = "Unlicense"
     description = "Loguru is a C++11 logging library."
 
     options = {
-        "use_fmtlib": [True, False],
         "shared": [True, False],
+        "fPIC": [True, False],
+        "use_fmtlib": [True, False],
         "catch_sigabrt": [True, False],
         "verbose_scope_endings": [True, False],
         "redefine_assert": [True, False],
@@ -42,8 +37,9 @@ class LoguruConan(ConanFile):
     }
 
     default_options = {
-        "use_fmtlib": False,
         "shared": False,
+        "fPIC": True,
+        "use_fmtlib": False,
         "catch_sigabrt": True,
         "verbose_scope_endings": True,
         "redefine_assert": False,
@@ -51,15 +47,19 @@ class LoguruConan(ConanFile):
         "with_fileabs": False,
         "with_rtti": True,
         "replace_glog": False,
-
-        "scope_text_size": None,         # default: 196
-        "filename_width": None,          # default: 23
-        "threadname_width": None,        # default: 16
-        "scope_time_precision": None,    # 3=ms, 6=us, 9=ns, default: 3
+        "scope_text_size": 196,
+        "filename_width": 23,
+        "threadname_width": 16,
+        "scope_time_precision": 3,
     }
 
-    def build_requirements(self):
-        self.tool_requires("cmake/3.25.0")
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def requirements(self):
         if self.options.use_fmtlib:
@@ -77,27 +77,21 @@ class LoguruConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-
+        tc.variables["LOGURU_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.variables["LOGURU_USE_FMTLIB"] = self.options.use_fmtlib
-        tc.variables["LOGURU_STATIC"] = not self.options.shared
-        tc.variables["LOGURU_CATCH_SIGABRT"] = _int(self.options.catch_sigabrt)
-        tc.variables["LOGURU_VERBOSE_SCOPE_ENDINGS"] = _int(self.options.verbose_scope_endings)
-        tc.variables["LOGURU_REDEFINE_ASSERT"] = _int(self.options.redefine_assert)
-        tc.variables["LOGURU_WITH_STREAMS"] = _int(self.options.with_streams)
-        tc.variables["LOGURU_WITH_FILEABS"] = _int(self.options.with_fileabs)
-        tc.variables["LOGURU_WITH_RTTI"] = _int(self.options.with_rtti)
-        tc.variables["LOGURU_REPLACE_GLOG"] = _int(self.options.replace_glog)
-
-        if self.options.scope_text_size:
-            tc.variables["LOGURU_SCOPE_TEXT_SIZE"] = self.options.scope_text_size
-        if self.options.filename_width:
-            tc.variables["LOGURU_FILENAME_WIDTH"] = self.options.filename_width
-        if self.options.threadname_width:
-            tc.variables["LOGURU_THREADNAME_WIDTH"] = self.options.threadname_width
-        if self.options.scope_time_precision:
-            tc.variables["LOGURU_SCOPE_TIME_PRECISION"] = self.options.scope_time_precision
-
+        tc.variables["LOGURU_CATCH_SIGABRT"] = int(eval(self.options.catch_sigabrt.value))
+        tc.variables["LOGURU_VERBOSE_SCOPE_ENDINGS"] = int(eval(self.options.verbose_scope_endings.value))
+        tc.variables["LOGURU_REDEFINE_ASSERT"] = int(eval(self.options.redefine_assert.value))
+        tc.variables["LOGURU_WITH_STREAMS"] = int(eval(self.options.with_streams.value))
+        tc.variables["LOGURU_WITH_FILEABS"] = int(eval(self.options.with_fileabs.value))
+        tc.variables["LOGURU_RTTI"] = int(eval(self.options.with_rtti.value))
+        tc.variables["LOGURU_REPLACE_GLOG"] = int(eval(self.options.replace_glog.value))
+        tc.variables["LOGURU_SCOPE_TEXT_SIZE"] = self.options.scope_text_size
+        tc.variables["LOGURU_FILENAME_WIDTH"] = self.options.filename_width
+        tc.variables["LOGURU_THREADNAME_WIDTH"] = self.options.threadname_width
+        tc.variables["LOGURU_SCOPE_TIME_PRECISION"] = self.options.scope_time_precision
         tc.generate()
+
         deps = CMakeDeps(self)
         deps.generate()
 
@@ -119,31 +113,27 @@ class LoguruConan(ConanFile):
         save(self, os.path.join(self.package_folder, 'licenses', 'LICENSE'), self._extracted_license)
 
     def package_info(self):
+        self.cpp_info.libs = ["loguru"]
         if self.options.use_fmtlib:
-            self.cpp_info.components["libloguru"].defines.append("LOGURU_USE_FMTLIB")
-            self.cpp_info.components["libloguru"].requires = ["fmt::fmt"]
+            self.cpp_info.defines.append("LOGURU_USE_FMTLIB")
+            self.cpp_info.requires = ["fmt::fmt"]
 
-        if self.options.scope_text_size:
-            self.cpp_info.components["libloguru"].defines.append(f"LOGURU_SCOPE_TEXT_SIZE={self.options.scope_text_size}")
-        if self.options.filename_width:
-            self.cpp_info.components["libloguru"].defines.append(f"LOGURU_FILENAME_WIDTH={self.options.filename_width}")
-        if self.options.threadname_width:
-            self.cpp_info.components["libloguru"].defines.append(f"LOGURU_THREADNAME_WIDTH={self.options.threadname_width}")
-        if self.options.scope_time_precision:
-            self.cpp_info.components["libloguru"].defines.append(f"LOGURU_SCOPE_TIME_PRECISION={self.options.scope_time_precision}")
-
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_CATCH_SIGABRT={_int(self.options.catch_sigabrt)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_VERBOSE_SCOPE_ENDINGS={_int(self.options.verbose_scope_endings)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_REDEFINE_ASSERT={_int(self.options.redefine_assert)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_WITH_STREAMS={_int(self.options.with_streams)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_WITH_FILEABS={_int(self.options.with_fileabs)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_WITH_RTTI={_int(self.options.with_rtti)}")
-        self.cpp_info.components["libloguru"].defines.append(f"LOGURU_REPLACE_GLOG={_int(self.options.replace_glog)}")
-
-        if not self.options.shared:
-            self.cpp_info.components["libloguru"].defines.append("LOGURU_USE_STATIC")
-
-        self.cpp_info.components["libloguru"].libs = ["loguru"]
+        self.cpp_info.defines.append(f"LOGURU_SCOPE_TEXT_SIZE={self.options.scope_text_size}")
+        self.cpp_info.defines.append(f"LOGURU_FILENAME_WIDTH={self.options.filename_width}")
+        self.cpp_info.defines.append(f"LOGURU_THREADNAME_WIDTH={self.options.threadname_width}")
+        self.cpp_info.defines.append(f"LOGURU_SCOPE_TIME_PRECISION={self.options.scope_time_precision}")
+        definitions = {
+            "LOGURU_CATCH_SIGABRT": self.options.catch_sigabrt,
+            "LOGURU_VERBOSE_SCOPE_ENDINGS": self.options.verbose_scope_endings,
+            "LOGURU_REDEFINE_ASSERT": self.options.redefine_assert,
+            "LOGURU_WITH_STREAMS": self.options.with_streams,
+            "LOGURU_WITH_FILEABS": self.options.with_fileabs,
+            "LOGURU_RTTI": self.options.with_rtti,
+            "LOGURU_REPLACE_GLOG": self.options.replace_glog
+        }
+        for key, value in definitions.items():
+            self.output.info(f"VALUE: {key} {value}")
+            self.cpp_info.defines.append(f"{key}={int(eval(value.value))}")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["libloguru"].system_libs = ["pthread", "dl"]
+            self.cpp_info.system_libs = ["pthread", "dl"]

--- a/recipes/loguru/all/conanfile.py
+++ b/recipes/loguru/all/conanfile.py
@@ -114,14 +114,12 @@ class LoguruConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["loguru"]
-        if self.options.use_fmtlib:
-            self.cpp_info.defines.append("LOGURU_USE_FMTLIB")
-            self.cpp_info.requires = ["fmt::fmt"]
 
         self.cpp_info.defines.append(f"LOGURU_SCOPE_TEXT_SIZE={self.options.scope_text_size}")
         self.cpp_info.defines.append(f"LOGURU_FILENAME_WIDTH={self.options.filename_width}")
         self.cpp_info.defines.append(f"LOGURU_THREADNAME_WIDTH={self.options.threadname_width}")
         self.cpp_info.defines.append(f"LOGURU_SCOPE_TIME_PRECISION={self.options.scope_time_precision}")
+        self.cpp_info.defines.append(f"LOGURU_USE_FMTLIB={int(eval(self.options.use_fmtlib.value))}")
         self.cpp_info.defines.append(f"LOGURU_CATCH_SIGABRT={int(eval(self.options.catch_sigabrt.value))}")
         self.cpp_info.defines.append(f"LOGURU_VERBOSE_SCOPE_ENDINGS={int(eval(self.options.verbose_scope_endings.value))}")
         self.cpp_info.defines.append(f"LOGURU_REDEFINE_ASSERT={int(eval(self.options.redefine_assert.value))}")

--- a/recipes/loguru/all/test_package/CMakeLists.txt
+++ b/recipes/loguru/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
-
 find_package(loguru REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/loguru/all/test_package/CMakeLists.txt
+++ b/recipes/loguru/all/test_package/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 find_package(loguru REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/loguru/all/test_package/conanfile.py
+++ b/recipes/loguru/all/test_package/conanfile.py
@@ -18,7 +18,6 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        #tc.variables["SPDLOG_HEADER_ONLY"] = self.dependencies["spdlog"].options.header_only
         tc.generate()
 
     def build(self):

--- a/recipes/loguru/all/test_package/test_package.cpp
+++ b/recipes/loguru/all/test_package/test_package.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
     LOG_F(INFO, "Verbose scope endings: {}", LOGURU_VERBOSE_SCOPE_ENDINGS);
     LOG_F(INFO, "Redefine assert: {}", LOGURU_REDEFINE_ASSERT);
     LOG_F(INFO, "With fileabs: {}", LOGURU_WITH_FILEABS);
-    LOG_F(INFO, "With rtti: {}", LOGURU_WITH_RTTI);
+    LOG_F(INFO, "With rtti: {}", LOGURU_RTTI);
     LOG_F(INFO, "With streams: {}", LOGURU_WITH_STREAMS);
 
 #if LOGURU_WITH_STREAMS == 1
@@ -35,4 +35,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-

--- a/recipes/loguru/all/test_v1_package/CMakeLists.txt
+++ b/recipes/loguru/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/loguru/all/test_v1_package/conanfile.py
+++ b/recipes/loguru/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Some considerations related to your original PR:

- Use BUILD_SHARED_LIBS from CMake, do not need a new shared/static option
- Add fPIC option
- Add option description in Cmake script
- Export all definitions to consumer compiler
- Use default values from upstream to configure arrays sizes


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
Signed-off-by: Uilian Ries <uilianries@gmail.com>